### PR TITLE
fixing how the clustering error is handled

### DIFF
--- a/myKmeans.m
+++ b/myKmeans.m
@@ -67,7 +67,7 @@ while 1
     iter = iter + 1;
     
     % check stopping criteria
-    if 1/RSS_error < TOL
+    if RSS_error < TOL
         break;
     end
     


### PR DESCRIPTION
This pull request suggests a more appropriate way of checking the clustering error as the means to stop k-means iterations.